### PR TITLE
fix: PR-Merge 시 develop 브랜치에 Merge 되어도 Issue 상태 변화하도록 지정

### DIFF
--- a/.github/workflows/pr-to-done.yml
+++ b/.github/workflows/pr-to-done.yml
@@ -3,6 +3,9 @@ name: Move PR Issues to Done
 on:
   pull_request:
     types: [closed]
+    branches:
+      - develop
+      - main
 
 jobs:
   move-to-done:


### PR DESCRIPTION
📌 관련 이슈 번호 #40 

<br>

📘 작업 유형
 - [ ] 신규 기능 추가
 - [ x ] 버그 수정
 - [ ] 리팩토링

<br>

📙 작업 내역 (구현 내용 및 작업 내역을 기재합니다.)
 - .github/workflows/pr-to-done.yml 파일의 PR 설정에 branches 옵션을 추가하여, develop, main 브랜치에 
 Merge 되어도 깃허브 Issue들의 상태들이 변화되도록 수정


<br>

📕 고민 내용 (자유롭게 생각했던 바를 작성합니다.)
 - PR이 통과되어도 Issue에 변화가 없어, 불편해서 방법을 찾아보다 해결하였습니다.

<br>

📋 체크리스트 (PR을 올리기 전에 스스로 확인해봐요!)
 - [ x ] PR 제목에 작업 내용을 요약하여 기재했는가?
 - [ x ] 코딩컨벤션을 준수하는가?
 - [ x ] 내 코드에 대해 스스로 검토를 했는가?

<br>

📝 특이 사항
